### PR TITLE
Mouse movements should be handled while panning the grid

### DIFF
--- a/src/hex.grid.js
+++ b/src/hex.grid.js
@@ -121,8 +121,8 @@ hex.extend(hex, {
         };
       
       // Handle panning
-      if (pan.panning) {
-        if (pan.enabled && inside) {
+      if (pan.panning && pan.enabled) {
+        if (inside) {
           var
             px = pos.x - pan.x,
             py = pos.y - pan.y;


### PR DESCRIPTION
If not panning, handling mouse movements events allows advanced functionality like moving hexagon cells to a different position.
